### PR TITLE
Fix transparent pixel

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,3 +104,4 @@ function imscii (read, options) {
     .then(paintASCII)
     .catch(console.error)
 }
+


### PR DESCRIPTION
I have changed the string that the "getChar" function returns for when the receiving pixel represents a transparent pixel, now it return a empty string. @mster 